### PR TITLE
Fixed attrs names and minSdk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,9 @@
 /build
 /captures
 .externalNativeBuild
+*.ser
+.idea/checkstyle-idea.xml
+.idea/codeStyles/Project.xml
+.idea/encodings.xml
+.idea/codeStyles/Project.xml
+.idea/misc.xml

--- a/LabProgress/build.gradle
+++ b/LabProgress/build.gradle
@@ -10,7 +10,7 @@ android {
 
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 21
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"

--- a/LabProgress/src/main/java/com/durranilab/labprogresslayout/LabProgressLayout.java
+++ b/LabProgress/src/main/java/com/durranilab/labprogresslayout/LabProgressLayout.java
@@ -99,7 +99,7 @@ public class LabProgressLayout extends View implements Animatable {
         maxProgress = maxProgress * 10;
         int loadedColor = a.getColor(R.styleable.LabProgressLayout_labLoadedColor, COLOR_LOADED_DEFAULT);
         int emptyColor = a.getColor(R.styleable.LabProgressLayout_labEmptyColor, COLOR_EMPTY_DEFAULT);
-        cornerRadius  = a.getInt(R.styleable.LabProgressLayout_labCornerRadius,0);
+        cornerRadius  = a.getDimensionPixelSize(R.styleable.LabProgressLayout_labCornerRadius,0);
         a.recycle();
 
         paintProgressEmpty = new Paint();

--- a/LabProgress/src/main/java/com/durranilab/labprogresslayout/LabProgressLayout.java
+++ b/LabProgress/src/main/java/com/durranilab/labprogresslayout/LabProgressLayout.java
@@ -8,6 +8,7 @@ import android.graphics.Paint;
 import android.graphics.drawable.Animatable;
 import android.os.Build;
 import android.os.Handler;
+import android.support.annotation.ColorRes;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.View;
@@ -142,6 +143,14 @@ public class LabProgressLayout extends View implements Animatable {
 
     public void setAutoProgress(boolean isAutoProgress) {
         this.isAutoProgress = isAutoProgress;
+    }
+
+    public void setProgressColor(int color) {
+        paintProgressLoaded.setColor(color);
+    }
+
+    public void setProgressEmptyColor(int color) {
+        paintProgressEmpty.setColor(color);
     }
 
     public void setProgressLayoutListener(LabProgressLayoutListener progressLayoutListener) {

--- a/LabProgress/src/main/java/com/durranilab/labprogresslayout/LabProgressLayout.java
+++ b/LabProgress/src/main/java/com/durranilab/labprogresslayout/LabProgressLayout.java
@@ -19,8 +19,8 @@ public class LabProgressLayout extends View implements Animatable {
     private static final int COLOR_LOADED_DEFAULT = 0x11FFFFFF;
     private static final int PROGRESS_SECOND_MS = 1000;
 
-    private static Paint paintProgressLoaded;
-    private static Paint paintProgressEmpty;
+    private Paint paintProgressLoaded;
+    private Paint paintProgressEmpty;
 
     private boolean isPlaying = false;
     private boolean isAutoProgress;

--- a/LabProgress/src/main/java/com/durranilab/labprogresslayout/LabProgressLayout.java
+++ b/LabProgress/src/main/java/com/durranilab/labprogresslayout/LabProgressLayout.java
@@ -92,13 +92,13 @@ public class LabProgressLayout extends View implements Animatable {
 
     private void init(Context context, AttributeSet attrs) {
         setWillNotDraw(false);
-        TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.progressLayout);
-        isAutoProgress = a.getBoolean(R.styleable.progressLayout_autoProgress, true);
-        maxProgress = a.getInt(R.styleable.progressLayout_maxProgress, 0);
+        TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.LabProgressLayout);
+        isAutoProgress = a.getBoolean(R.styleable.LabProgressLayout_labAutoProgress, true);
+        maxProgress = a.getInt(R.styleable.LabProgressLayout_labMaxProgress, 0);
         maxProgress = maxProgress * 10;
-        int loadedColor = a.getColor(R.styleable.progressLayout_loadedColor, COLOR_LOADED_DEFAULT);
-        int emptyColor = a.getColor(R.styleable.progressLayout_emptyColor, COLOR_EMPTY_DEFAULT);
-        cornerRadius  = a.getInt(R.styleable.progressLayout_cornerRadius,0);
+        int loadedColor = a.getColor(R.styleable.LabProgressLayout_labLoadedColor, COLOR_LOADED_DEFAULT);
+        int emptyColor = a.getColor(R.styleable.LabProgressLayout_labEmptyColor, COLOR_EMPTY_DEFAULT);
+        cornerRadius  = a.getInt(R.styleable.LabProgressLayout_labCornerRadius,0);
         a.recycle();
 
         paintProgressEmpty = new Paint();

--- a/LabProgress/src/main/res/values/attrs.xml
+++ b/LabProgress/src/main/res/values/attrs.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <declare-styleable name="progressLayout">
-        <attr name="emptyColor" format="color" />
-        <attr name="loadedColor" format="color" />
-        <attr name="maxProgress" format="integer" />
-        <attr name="autoProgress" format="boolean"/>
-        <attr name="cornerRadius" format="integer"/>
+    <declare-styleable name="LabProgressLayout">
+        <attr name="labEmptyColor" format="color" />
+        <attr name="labLoadedColor" format="color" />
+        <attr name="labMaxProgress" format="integer" />
+        <attr name="labAutoProgress" format="boolean"/>
+        <attr name="labCornerRadius" format="integer"/>
     </declare-styleable>
 </resources>

--- a/LabProgress/src/main/res/values/attrs.xml
+++ b/LabProgress/src/main/res/values/attrs.xml
@@ -5,6 +5,6 @@
         <attr name="labLoadedColor" format="color" />
         <attr name="labMaxProgress" format="integer" />
         <attr name="labAutoProgress" format="boolean"/>
-        <attr name="labCornerRadius" format="integer"/>
+        <attr name="labCornerRadius" format="dimension"/>
     </declare-styleable>
 </resources>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
     defaultConfig {
         applicationId "com.durranilab.labprogresslayoutapp"
-        minSdkVersion 16
+        minSdkVersion 21
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -33,11 +33,11 @@
                 android:layout_alignParentStart="true"
                 android:layout_centerVertical="true"
                 android:layout_margin="10dp"
-                app:autoProgress="true"
-                app:cornerRadius="10"
-                app:emptyColor="#e8f5e9"
-                app:loadedColor="#81c784"
-                app:maxProgress="100" />
+                app:labAutoProgress="true"
+                app:labCornerRadius="10"
+                app:labEmptyColor="#e8f5e9"
+                app:labLoadedColor="#81c784"
+                app:labMaxProgress="100" />
 
 
         </RelativeLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -29,12 +29,12 @@
             <com.durranilab.labprogresslayout.LabProgressLayout
                 android:id="@+id/labProgressLayout"
                 android:layout_width="match_parent"
-                android:layout_height="10dp"
+                android:layout_height="18dp"
                 android:layout_alignParentStart="true"
                 android:layout_centerVertical="true"
                 android:layout_margin="10dp"
                 app:labAutoProgress="true"
-                app:labCornerRadius="10"
+                app:labCornerRadius="10dp"
                 app:labEmptyColor="#e8f5e9"
                 app:labLoadedColor="#81c784"
                 app:labMaxProgress="100" />


### PR DESCRIPTION
- cornerRadius attribute was clashing with other Material Design library attributes
- drawRoundRect method used in this library requires minSdk 21, but it was set to 16 (don't have time to make some compatibility mode, my minSdk is 21 so if you need 16 update my PR)